### PR TITLE
[Bugfix] Remove deprecated ugettext_lazy from blog.forms

### DIFF
--- a/pinax/blog/forms.py
+++ b/pinax/blog/forms.py
@@ -3,7 +3,7 @@ from functools import partial as curry
 from django import forms
 from django.utils import timezone
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from pinax.images.models import ImageSet
 


### PR DESCRIPTION
- [Bugfix] Remove deprecated ugettext_lazy from blog.forms