### PR TITLE
Remove deprecated use of django.conf.urls url and use re_path instead

### DIFF
--- a/pinax/blog/urls.py
+++ b/pinax/blog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .conf import settings
 from .views import (
@@ -19,19 +19,19 @@ from .views import (
 app_name = "pinax_blog"
 
 urlpatterns = [
-    url(r"^$", BlogIndexView.as_view(), name="blog"),
-    url(r"^section/(?P<section>[-\w]+)/$", SectionIndexView.as_view(), name="blog_section"),
-    url(r"^post/(?P<post_pk>\d+)/$", StaffPostDetailView.as_view(), name="blog_post_pk"),
-    url(r"^post/(?P<post_secret_key>\w+)/$", SecretKeyPostDetailView.as_view(), name="blog_post_secret"),
-    url(r"^feed/(?P<section>[-\w]+)/(?P<feed_type>[-\w]+)/$", blog_feed, name="blog_feed"),
+    re_path(r"^$", BlogIndexView.as_view(), name="blog"),
+    re_path(r"^section/(?P<section>[-\w]+)/$", SectionIndexView.as_view(), name="blog_section"),
+    re_path(r"^post/(?P<post_pk>\d+)/$", StaffPostDetailView.as_view(), name="blog_post_pk"),
+    re_path(r"^post/(?P<post_secret_key>\w+)/$", SecretKeyPostDetailView.as_view(), name="blog_post_secret"),
+    re_path(r"^feed/(?P<section>[-\w]+)/(?P<feed_type>[-\w]+)/$", blog_feed, name="blog_feed"),
 
     # authoring
-    url(r"^manage/posts/$", ManagePostList.as_view(), name="manage_post_list"),
-    url(r"^manage/posts/create/$", ManageCreatePost.as_view(), name="manage_post_create"),
-    url(r"^manage/posts/(?P<post_pk>\d+)/update/$", ManageUpdatePost.as_view(), name="manage_post_update"),
-    url(r"^manage/posts/(?P<post_pk>\d+)/delete/$", ManageDeletePost.as_view(), name="manage_post_delete"),
+    re_path(r"^manage/posts/$", ManagePostList.as_view(), name="manage_post_list"),
+    re_path(r"^manage/posts/create/$", ManageCreatePost.as_view(), name="manage_post_create"),
+    re_path(r"^manage/posts/(?P<post_pk>\d+)/update/$", ManageUpdatePost.as_view(), name="manage_post_update"),
+    re_path(r"^manage/posts/(?P<post_pk>\d+)/delete/$", ManageDeletePost.as_view(), name="manage_post_delete"),
 
-    url(r"^ajax/markdown/preview/$", ajax_preview, name="ajax_preview")
+    re_path(r"^ajax/markdown/preview/$", ajax_preview, name="ajax_preview")
 ]
 
 


### PR DESCRIPTION
- Remove deprecated use of django.conf.urls url and use re_path instead