### PR TITLE
Feature/delete blog post

### DIFF
--- a/pinax/blog/hooks.py
+++ b/pinax/blog/hooks.py
@@ -27,8 +27,8 @@ class PinaxBlogDefaultHookSet:
         return request.user.is_staff
 
     def user_can_manage(self, request, *args, **kwargs):
-        post_user_id = kwargs.get("post_user_id")
-        return post_user_id == request.user.id
+        author_id = kwargs.get("author_id")
+        return author_id == request.user.id
 
     def staff_can_manage(self, request, *args, **kwargs):
         return request.user.is_staff

--- a/pinax/blog/hooks.py
+++ b/pinax/blog/hooks.py
@@ -28,10 +28,13 @@ class PinaxBlogDefaultHookSet:
 
     def user_can_manage(self, request, *args, **kwargs):
         post_user_id = kwargs.get("post_user_id")
-        return request.user.is_authenticated and post_user_id == request.user.id
+        return post_user_id == request.user.id
 
     def staff_can_manage(self, request, *args, **kwargs):
         return request.user.is_staff
+
+    def user_authenticated(self, request, *args, **kwargs):
+        return request.user.is_authenticated
 
     def response_cannot_manage(self, request, *args, **kwargs):
         """

--- a/pinax/blog/hooks.py
+++ b/pinax/blog/hooks.py
@@ -26,8 +26,9 @@ class PinaxBlogDefaultHookSet:
     def can_manage(self, request, *args, **kwargs):
         return request.user.is_staff
 
-    def user_can_manage(self, request, post_id, *args, **kwargs):
-        return request.user.is_authenticated and post_id == request.user.id
+    def user_can_manage(self, request, *args, **kwargs):
+        post_user_id = kwargs.get("post_user_id")
+        return request.user.is_authenticated and post_user_id == request.user.id
 
     def staff_can_manage(self, request, *args, **kwargs):
         return request.user.is_staff

--- a/pinax/blog/templates/pagination/_pagination.html
+++ b/pinax/blog/templates/pagination/_pagination.html
@@ -1,0 +1,50 @@
+
+{# Pagination for default django.core.paginator.Paginator #}
+{# This template will work with CBV views with ``paginate_by`` specified. #}
+{% load i18n %}
+
+{% if is_paginated %}
+<nav class="page-navigation" aria-label="page navigation">
+    <ul>
+        {% if page_obj.has_previous %}
+            <li class="prev">
+                <a href="?page={{ page_obj.previous_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">
+                    <i class="fas fa-long-arrow-alt-left"></i>
+                    {% trans "Previous" %}
+                </a>
+            </li>
+        {% else %}
+            <li class="prev disabled">
+                <a>{% block pagination_previous_label %}<i class="fas fa-long-arrow-alt-left"></i> {% trans "Previous" %}{% endblock %}</a>
+            </li>
+        {% endif %}
+        {% for page in paginator.page_range %}
+        {% if page == page_obj.number %}
+            <li class="active">
+                <a href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a>
+            </li>
+        {% else %}
+            <li class="">
+                <a href="?page={{ page|stringformat:"d" }}{{ getvars }}{{ hashtag }}">{{ page|stringformat:"d" }}</a>
+            </li>
+        {% endif %}
+        {% endfor %}
+        {% if page_obj.has_next %}
+            <li class="next">
+                <a href="?page={{ page_obj.next_page_number|stringformat:"d" }}{{ getvars }}{{ hashtag }}">
+                    {% trans "Next" %}
+                    <i class="fas fa-long-arrow-alt-right"></i>
+                </a>
+            </li>
+        {% else %}
+            <li class="next disabled">
+                <a>{% block pagination_next_label %}
+                    {% trans "Next" %}
+                    <i class="fas fa-long-arrow-alt-right"></i>
+                    {% endblock %}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</nav>
+{% endif %}

--- a/pinax/blog/tests/test_blog.py
+++ b/pinax/blog/tests/test_blog.py
@@ -182,7 +182,7 @@ class TestViews(TestBlog):
     def test_user_manage_post_list(self):
         url = reverse("pinax_blog:manage_post_list")
         response = self.client.get(url)
-        self.assertEqual(response.context_data["post_list"].count(), 0)
+        self.assertEqual(response.status_code, 404)
 
         with self.login(self.user):
             url = reverse("pinax_blog:manage_post_list")

--- a/pinax/blog/tests/test_blog.py
+++ b/pinax/blog/tests/test_blog.py
@@ -143,12 +143,9 @@ class TestViews(TestBlog):
         Ensure template with external URL references renders properly
         for user with proper credentials.
         """
-        # with self.login(self.user):
         response = self.client.get("pinax_blog:manage_post_create")
         self.assertEqual(response.status_code, 404)
 
-        # self.user.is_staff = True
-        # self.user.save()
         with self.login(self.user):
             self.get("pinax_blog:manage_post_create")
             self.response_200()
@@ -161,8 +158,6 @@ class TestViews(TestBlog):
         Ensure template with external URL references renders properly
         for user with proper credentials.
         """
-        # self.user.is_staff = True
-        # self.user.save()
         post_title = "You'll never believe what happened next!"
         post_data = dict(
             section=self.apples.pk,
@@ -239,25 +234,3 @@ class TestViews(TestBlog):
             response = self.client.get(url)
             self.assertEqual(response.status_code, 200)
             self.assertTemplateUsed("pinax/blog/manage_post_update")
-
-    # def test_manage_update_post_post_author(self):
-    #     post_title = "Orange You Great"
-    #     post_data = Post.objects.create(
-    #         blog=self.blog,
-    #         section=self.oranges,
-    #         title=post_title,
-    #         slug=self.orange_slug,
-    #         author=self.user,
-    #         markup=self.markup,
-    #         state=Post.STATE_CHOICES[-1][0],
-    #     )
-    #     with self.login(self.user):
-    #         print(self.user)
-    #         self.post("pinax_blog:manage_post_update", data=post_data, kwargs={"post_pk": "1"})
-    #         self.assertRedirects(
-    #             self.last_response, reverse("pinax_blog:manage_post_list")
-    #         )
-    #         self.assertTrue(Post.objects.get(title=post_title))
-
-
-

--- a/pinax/blog/tests/test_blog.py
+++ b/pinax/blog/tests/test_blog.py
@@ -211,9 +211,6 @@ class TestViews(TestBlog):
             self.assertIn(self.orange2_post, response.context_data["post_list"])
 
     def test_manage_update_post_get_author(self):
-        url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
 
         with self.login(self.user):
             url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
@@ -222,6 +219,10 @@ class TestViews(TestBlog):
             self.assertTemplateUsed("pinax/blog/manage_post_update")
 
     def test_manage_update_post_get_not_author(self):
+        url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
         self.user = self.make_user("jani")
         self.user.save()
 

--- a/pinax/blog/tests/test_blog.py
+++ b/pinax/blog/tests/test_blog.py
@@ -210,4 +210,53 @@ class TestViews(TestBlog):
             self.assertEqual(response.context_data["post_list"].count(), 1)
             self.assertIn(self.orange2_post, response.context_data["post_list"])
 
+    def test_manage_update_post_get_author(self):
+        url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
+        with self.login(self.user):
+            url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateUsed("pinax/blog/manage_post_update")
+
+    def test_manage_update_post_get_not_author(self):
+        self.user = self.make_user("jani")
+        self.user.save()
+
+        with self.login(self.user):
+            url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
+
+        self.user.is_staff = True
+        self.user.save()
+
+        with self.login(self.user):
+            url = reverse("pinax_blog:manage_post_update", kwargs={"post_pk": "1"})
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertTemplateUsed("pinax/blog/manage_post_update")
+
+    # def test_manage_update_post_post_author(self):
+    #     post_title = "Orange You Great"
+    #     post_data = Post.objects.create(
+    #         blog=self.blog,
+    #         section=self.oranges,
+    #         title=post_title,
+    #         slug=self.orange_slug,
+    #         author=self.user,
+    #         markup=self.markup,
+    #         state=Post.STATE_CHOICES[-1][0],
+    #     )
+    #     with self.login(self.user):
+    #         print(self.user)
+    #         self.post("pinax_blog:manage_post_update", data=post_data, kwargs={"post_pk": "1"})
+    #         self.assertRedirects(
+    #             self.last_response, reverse("pinax_blog:manage_post_list")
+    #         )
+    #         self.assertTrue(Post.objects.get(title=post_title))
+
+
 

--- a/pinax/blog/tests/test_blog.py
+++ b/pinax/blog/tests/test_blog.py
@@ -143,12 +143,12 @@ class TestViews(TestBlog):
         Ensure template with external URL references renders properly
         for user with proper credentials.
         """
-        with self.login(self.user):
-            response = self.client.get("pinax_blog:manage_post_create")
-            self.assertEqual(response.status_code, 404)
+        # with self.login(self.user):
+        response = self.client.get("pinax_blog:manage_post_create")
+        self.assertEqual(response.status_code, 404)
 
-        self.user.is_staff = True
-        self.user.save()
+        # self.user.is_staff = True
+        # self.user.save()
         with self.login(self.user):
             self.get("pinax_blog:manage_post_create")
             self.response_200()
@@ -161,8 +161,8 @@ class TestViews(TestBlog):
         Ensure template with external URL references renders properly
         for user with proper credentials.
         """
-        self.user.is_staff = True
-        self.user.save()
+        # self.user.is_staff = True
+        # self.user.save()
         post_title = "You'll never believe what happened next!"
         post_data = dict(
             section=self.apples.pk,

--- a/pinax/blog/urls.py
+++ b/pinax/blog/urls.py
@@ -6,6 +6,7 @@ from .views import (
     DateBasedPostDetailView,
     ManageCreatePost,
     ManageDeletePost,
+    UserManageDeletePost,
     ManagePostList,
     UserManagePostList,
     ManageUpdatePost,
@@ -52,7 +53,7 @@ urlpatterns = [
     ),
     re_path(
         r"^manage/posts/(?P<post_pk>\d+)/delete/$",
-        ManageDeletePost.as_view(),
+        UserManageDeletePost.as_view(),
         name="manage_post_delete",
     ),
     re_path(r"^ajax/markdown/preview/$", ajax_preview, name="ajax_preview"),

--- a/pinax/blog/urls.py
+++ b/pinax/blog/urls.py
@@ -9,6 +9,7 @@ from .views import (
     ManagePostList,
     UserManagePostList,
     ManageUpdatePost,
+    UserManageUpdatePost,
     SecretKeyPostDetailView,
     SectionIndexView,
     SlugUniquePostDetailView,
@@ -46,7 +47,7 @@ urlpatterns = [
     ),
     re_path(
         r"^manage/posts/(?P<post_pk>\d+)/update/$",
-        ManageUpdatePost.as_view(),
+        UserManageUpdatePost.as_view(),
         name="manage_post_update",
     ),
     re_path(

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -272,7 +272,7 @@ class UserManagePostList(UserManageBlogMixin, ListView):
         return qs
 
 
-class ManageCreatePost(ManageBlogMixin, ManageSuccessUrlMixin, CreateView):
+class ManageCreatePost(UserManageBlogMixin, ManageSuccessUrlMixin, CreateView):
 
     model = Post
     form_class = PostForm

--- a/pinax/blog/views.py
+++ b/pinax/blog/views.py
@@ -244,8 +244,10 @@ class UserManageBlogMixin:
         self.request = request
         self.args = args
         self.kwargs = kwargs
-        self.blog = hookset.get_blog(**kwargs)
-        return super().dispatch(request, *args, **kwargs)
+        if hookset.user_authenticated(request, *args):
+            self.blog = hookset.get_blog(**kwargs)
+            return super().dispatch(request, *args, **kwargs)
+        return hookset.response_cannot_manage(request, *args, **kwargs)
 
 
 class ManagePostList(ManageBlogMixin, ListView):


### PR DESCRIPTION
- overriding _pagination.html default implementation
- renaming local variables
- Merge branch 'feature/blog-pagination' into feature/user-blog-post-management-page
- creating new hook for checking if user is logged in
- refactoring UserManageBlogMixin so it sends 404 response when a user is not authenticated
- changing user manage test for the new UserManageBlogMixin implementation
- refactoring ManageCreatePost view, user doesnt need staff role to create post
- refactoring test for blog post creation, user doesnt need staff role
- creating new view function --> regular users can only update their own posts
- adding and using new view (UserManageUpdatePost) for update post url
- creating tests for updating post
- using UserManageDeletePost for deleting posts
- moving test case to another method